### PR TITLE
Ensure that custom dusts are only retrieved when necessary and loaded

### DIFF
--- a/Content/Tiles/CrystalWoodChair.cs
+++ b/Content/Tiles/CrystalWoodChair.cs
@@ -29,7 +29,8 @@ namespace CrystiliumMod.Content.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("CrystalWood Chair");
 			AddMapEntry(new Color(250, 140, 250), name);
-			DustType = Mod.Find<ModDust>("CrystalDust").Type;
+			if (!Main.dedServ)
+				DustType = Mod.Find<ModDust>("CrystalDust").Type;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 			AdjTiles = new int[] { TileID.Chairs };
 		}

--- a/Content/Tiles/CrystalWoodChest.cs
+++ b/Content/Tiles/CrystalWoodChest.cs
@@ -42,7 +42,8 @@ namespace CrystiliumMod.Content.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Crystal Wood Chest");
 			AddMapEntry(new Color(250, 140, 250), name, MapChestName);
-			DustType = Mod.Find<ModDust>("CrystalDust").Type;
+			if (!Main.dedServ)
+				DustType = Mod.Find<ModDust>("CrystalDust").Type;
 			AdjTiles = new int[] { TileID.Containers };
 			ChestDrop = ModContent.ItemType<Items.Placeable.CrystalWoodChest>();
 			ContainerName.SetDefault("Crystal Wood Chest");

--- a/Content/Tiles/CrystalWoodDoorClosed.cs
+++ b/Content/Tiles/CrystalWoodDoorClosed.cs
@@ -38,7 +38,8 @@ namespace CrystiliumMod.Content.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("CrystalWood Door");
 			AddMapEntry(new Color(250, 140, 250), name);
-			DustType = Mod.Find<ModDust>("CrystalDust").Type;
+			if (!Main.dedServ)
+				DustType = Mod.Find<ModDust>("CrystalDust").Type;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 			AdjTiles = new int[] { TileID.ClosedDoor };
 			OpenDoorID = ModContent.TileType<CrystalWoodDoorOpen>();

--- a/Content/Tiles/CrystalWoodWorkbench.cs
+++ b/Content/Tiles/CrystalWoodWorkbench.cs
@@ -23,7 +23,8 @@ namespace CrystiliumMod.Content.Tiles
 			ModTranslation name = CreateMapEntryName();
 			name.SetDefault("Crystal Wood Workbench");
 			AddMapEntry(new Color(250, 140, 250), name);
-			DustType = Mod.Find<ModDust>("CrystalDust").Type;
+			if (!Main.dedServ)
+				DustType = Mod.Find<ModDust>("CrystalDust").Type;
 			TileID.Sets.DisableSmartCursor[Type] = true;
 			AdjTiles = new int[] { TileID.WorkBenches };
 		}

--- a/CrystiliumMod.csproj
+++ b/CrystiliumMod.csproj
@@ -16,6 +16,4 @@
     <None Include="Content\Gores\Crystal_Archer_Gore_1.png" />
     <None Include="Content\Gores\Crystal_Archer_Gore_2.png" />
   </ItemGroup>
-  <ItemGroup>
-  </ItemGroup>
 </Project>

--- a/CrystiliumMod.csproj
+++ b/CrystiliumMod.csproj
@@ -16,4 +16,18 @@
     <None Include="Content\Gores\Crystal_Archer_Gore_1.png" />
     <None Include="Content\Gores\Crystal_Archer_Gore_2.png" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="FNA">
+      <HintPath>G:\SteamLibrary\steamapps\common\tModLoader\Libraries\FNA\1.0.0\FNA.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net">
+      <HintPath>G:\SteamLibrary\steamapps\common\tModLoader\Libraries\log4net\2.0.8.0\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="ReLogic">
+      <HintPath>G:\SteamLibrary\steamapps\common\tModLoader\Libraries\ReLogic\1.0.0\ReLogic.dll</HintPath>
+    </Reference>
+    <Reference Include="tModLoader">
+      <HintPath>G:\SteamLibrary\steamapps\common\tModLoader\tModLoader.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/CrystiliumMod.csproj
+++ b/CrystiliumMod.csproj
@@ -17,17 +17,5 @@
     <None Include="Content\Gores\Crystal_Archer_Gore_2.png" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FNA">
-      <HintPath>G:\SteamLibrary\steamapps\common\tModLoader\Libraries\FNA\1.0.0\FNA.dll</HintPath>
-    </Reference>
-    <Reference Include="log4net">
-      <HintPath>G:\SteamLibrary\steamapps\common\tModLoader\Libraries\log4net\2.0.8.0\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="ReLogic">
-      <HintPath>G:\SteamLibrary\steamapps\common\tModLoader\Libraries\ReLogic\1.0.0\ReLogic.dll</HintPath>
-    </Reference>
-    <Reference Include="tModLoader">
-      <HintPath>G:\SteamLibrary\steamapps\common\tModLoader\tModLoader.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>

--- a/SpawnCondition.cs
+++ b/SpawnCondition.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria;
+﻿using Terraria;
 using Terraria.GameContent.Bestiary;
 using Terraria.GameContent.UI.Elements;
-using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.UI;
 using ReLogic.Content;


### PR DESCRIPTION
tModLoader only loads dusts on client side, causing dedicated servers to error when trying to load content that uses custom dusts.
